### PR TITLE
update name of jupyter_protocol package to match jupyter_protocol

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from __future__ import print_function
 
 # the name of the project
-name = 'jupyter_client'
+name = 'jupyter_protocol'
 
 #-----------------------------------------------------------------------------
 # Minimal Python version sanity check


### PR DESCRIPTION
Not sure if this was intentional… but this seemed to be a straightforward fix.