### PR TITLE
Replace jupyter_client refs with appropriate sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 .cache
 .pytest_cache
 absolute.json
+.idea/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# jupyter_client documentation build configuration file, created by
+# jupyter_protocol documentation build configuration file, created by
 # sphinx-quickstart on Tue May 26 15:41:51 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -51,7 +51,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'jupyter_client'
+project = 'jupyter_protocol'
 copyright = '2015, Jupyter Development Team'
 author = 'Jupyter Development Team'
 
@@ -61,7 +61,7 @@ author = 'Jupyter Development Team'
 #
 version_ns = {}
 here = os.path.dirname(__file__)
-version_py = os.path.join(here, os.pardir, 'jupyter_client', '_version.py')
+version_py = os.path.join(here, os.pardir, 'jupyter_protocol', '_version.py')
 with open(version_py) as f:
     exec(compile(f.read(), version_py, 'exec'), version_ns)
 
@@ -211,7 +211,7 @@ html_theme = 'sphinx_rtd_theme'
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'jupyter_clientdoc'
+htmlhelp_basename = 'jupyter_protocoldoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -233,7 +233,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'jupyter_client.tex', 'jupyter\\_client Documentation',
+  (master_doc, 'jupyter_protocol.tex', 'jupyter\\_protocol Documentation',
    'Jupyter Development Team', 'manual'),
 ]
 
@@ -263,7 +263,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'jupyter_client', 'jupyter_client Documentation',
+    (master_doc, 'jupyter_protocol', 'jupyter_protocol Documentation',
      [author], 1)
 ]
 
@@ -277,8 +277,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'jupyter_client', 'jupyter_client Documentation',
-   author, 'jupyter_client', 'One line description of project.',
+  (master_doc, 'jupyter_protocol', 'jupyter_protocol Documentation',
+   author, 'jupyter_protocol', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/kernel_providers.rst
+++ b/docs/kernel_providers.rst
@@ -15,7 +15,7 @@ and start kernels. For example, you could find kernels in an environment system
 like conda, or kernels on remote systems which you can access.
 
 To write a kernel provider, subclass
-:class:`jupyter_client.discovery.KernelProviderBase`, giving your provider an ID
+:class:`jupyter_kernel_mgmt.discovery.KernelProviderBase`, giving your provider an ID
 and overriding two methods.
 
 .. class:: MyKernelProvider
@@ -32,7 +32,7 @@ and overriding two methods.
       *name* is a short string identifying the kernel type.
       *attributes* is a dictionary with information to allow selecting a kernel.
 
-   .. method:: make_manager(name)
+   .. method:: launch(name)
 
       Prepare and return a :class:`~jupyter_client.KernelManager` instance
       ready to start a new kernel instance of the type identified by *name*.
@@ -42,7 +42,7 @@ For example, imagine we want to tell Jupyter about kernels for a new language
 called *oblong*::
 
     # oblong_provider.py
-    from jupyter_client.discovery import KernelProviderBase
+    from jupyter_kernel_mgmt.discovery import KernelProviderBase
     from jupyter_client import KernelManager
     from shutil import which
 
@@ -66,7 +66,7 @@ called *oblong*::
                 'argv': ['oblong-kernel'],
             }
 
-        def make_manager(self, name):
+        def launch(self, name):
             if name == 'standard':
                 return KernelManager(kernel_cmd=['oblong-kernel'],
                                      extra_env={'ROUNDED': '0'})
@@ -81,7 +81,7 @@ something like this::
 
     setup(...
         entry_points = {
-        'jupyter_client.kernel_providers' : [
+        'jupyter_kernel_mgmt.kernel_type_providers' : [
             # The name before the '=' should match the id attribute
             'oblong = oblong_provider:OblongKernelProvider',
         ]
@@ -91,15 +91,15 @@ Finding kernel types
 ====================
 
 To find and start kernels in client code, use
-:class:`jupyter_client.discovery.KernelFinder`. This uses multiple kernel
+:class:`jupyter_kernel_mgmt.discovery.KernelFinder`. This uses multiple kernel
 providers to find available kernels. Like a kernel provider, it has methods
-``find_kernels`` and ``make_manager``. The kernel names it works
+``find_kernels`` and ``launch``. The kernel names it works
 with have the provider ID as a prefix, e.g. ``oblong/rounded`` (from the example
 above).
 
 ::
 
-    from jupyter_client.discovery import KernelFinder
+    from jupyter_kernel_mgmt.discovery import KernelFinder
     kf = KernelFinder.from_entrypoints()
 
     ## Find available kernel types
@@ -110,10 +110,10 @@ above).
     # ...
 
     ## Start a kernel by name
-    manager = kf.make_manager('oblong/standard')
+    manager = kf.launch('oblong/standard')
     manager.start_kernel()
 
-.. module:: jupyter_client.discovery
+.. module:: jupyter_kernel_mgmt.discovery
 
 .. autoclass:: KernelFinder
 
@@ -121,7 +121,7 @@ above).
 
    .. automethod:: find_kernels
 
-   .. automethod:: make_manager
+   .. automethod:: launch
 
 Kernel providers included in ``jupyter_client``
 ===============================================

--- a/jupyter_protocol/adapter.py
+++ b/jupyter_protocol/adapter.py
@@ -6,7 +6,8 @@
 import re
 import json
 
-from jupyter_client import protocol_version_info
+from . import protocol_version_info
+
 
 def code_to_line(code, cursor_pos):
     """Turn a multiline code block and cursor position into a single line
@@ -28,6 +29,7 @@ def code_to_line(code, cursor_pos):
 _match_bracket = re.compile(r'\([^\(\)]+\)', re.UNICODE)
 _end_bracket = re.compile(r'\([^\(]*$', re.UNICODE)
 _identifier = re.compile(r'[a-z_][0-9a-z._]*', re.I|re.UNICODE)
+
 
 def extract_oname_v4(code, cursor_pos):
     """Reimplement token-finding logic from IPython 2.x javascript
@@ -95,6 +97,7 @@ class Adapter(object):
             return self.handle_reply_status_error(msg)
         return handler(msg)
 
+
 def _version_str_to_list(version):
     """convert a version string to a list of ints
 
@@ -107,6 +110,7 @@ def _version_str_to_list(version):
         except ValueError:
             pass
     return v
+
 
 class V5toV4(Adapter):
     """Adapt msg protocol v5 to v4"""
@@ -362,7 +366,6 @@ class V4toV5(Adapter):
     def input_request(self, msg):
         msg['content'].setdefault('password', False)
         return msg
-
 
 
 def adapt(msg, to_version=protocol_version_info[0]):

--- a/jupyter_protocol/session.py
+++ b/jupyter_protocol/session.py
@@ -14,11 +14,11 @@ import warnings
 
 from zmq.utils import jsonapi
 
-from jupyter_client.jsonutil import extract_dates, date_default
 from ipython_genutils.py3compat import (str_to_bytes, unicode_type,)
 
-from jupyter_client.adapter import adapt
 from traitlets.log import get_logger
+from .adapter import adapt
+from .jsonutil import extract_dates, date_default
 from .messages import Message
 
 

--- a/jupyter_protocol/tests/test_public_api.py
+++ b/jupyter_protocol/tests/test_public_api.py
@@ -1,4 +1,4 @@
-"""Test the jupyter_client public API
+"""Test the jupyter_protocol public API
 """
 
 # Copyright (c) Jupyter Development Team.

--- a/jupyter_protocol/tests/utils.py
+++ b/jupyter_protocol/tests/utils.py
@@ -1,4 +1,4 @@
-"""Testing utils for jupyter_client tests
+"""Testing utils for jupyter_protocol tests
 
 """
 import os


### PR DESCRIPTION
A few locations in the code were referencing `jupyter_client` in the import statements when the applicable references were local.

Started going down the same road in the docs, but stopped because it was getting into areas that require deeper effort and, since this was still experimental, I decided it might be best to spend time continuing the "experiment".  In addition, the docs, by virtue of `jupyter_client` essentially being the union of `jupyter_protocol` and `jupyter_kernel_mgmt`, require some reorganization and coordination between the (now) two repositories (i.e., we probably need to split out the stuff that belongs in `jupyter_kernel_mgmt` docs).