### PR TITLE
Remove jupyter_client references

### DIFF
--- a/jupyter_protocol/adapter.py
+++ b/jupyter_protocol/adapter.py
@@ -6,7 +6,7 @@
 import re
 import json
 
-from jupyter_client import protocol_version_info
+from jupyter_protocol import protocol_version_info
 
 def code_to_line(code, cursor_pos):
     """Turn a multiline code block and cursor position into a single line

--- a/jupyter_protocol/session.py
+++ b/jupyter_protocol/session.py
@@ -14,10 +14,10 @@ import warnings
 
 from zmq.utils import jsonapi
 
-from jupyter_client.jsonutil import extract_dates, date_default
+from jupyter_protocol.jsonutil import extract_dates, date_default
 from ipython_genutils.py3compat import (str_to_bytes, unicode_type,)
 
-from jupyter_client.adapter import adapt
+from jupyter_protocol.adapter import adapt
 from traitlets.log import get_logger
 from .messages import Message
 

--- a/jupyter_protocol/tests/test_public_api.py
+++ b/jupyter_protocol/tests/test_public_api.py
@@ -1,4 +1,4 @@
-"""Test the jupyter_client public API
+"""Test the jupyter_protocol public API
 """
 
 # Copyright (c) Jupyter Development Team.

--- a/jupyter_protocol/tests/utils.py
+++ b/jupyter_protocol/tests/utils.py
@@ -1,4 +1,4 @@
-"""Testing utils for jupyter_client tests
+"""Testing utils for jupyter_protocol tests
 
 """
 import os


### PR DESCRIPTION
Some import statements and comments remained from their jupyter_client origins - not any more.